### PR TITLE
Add __pycache__ to gitignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 build/
 MANIFEST
+__pycache__/


### PR DESCRIPTION
We use pymeta3 as a submodule in a project (during build) and after running the build, the submodule keeps showing as altered (with untracked files in the directory tree). It turns out that `__pycache__` is the culprit. 

This MR adds `__pycache__` to the `.gitignore` list.